### PR TITLE
Add SoundCloud, Facebook, and Twitch domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Menu interaktif **yt-dlp** untuk Windows, dengan fitur:
 - Output dipisah otomatis (mp4/mp3/thumb + single/playlist)
-- Downloader per domain (YouTube/TikTok/Bilibili → internal, Twitter/Reddit/Instagram → aria2c)
+- Downloader per domain (YouTube/TikTok/Bilibili/Facebook/Twitch → internal, Twitter/Reddit/Instagram/SoundCloud → aria2c)
 - **MP4 tidak lagi embed thumbnail** (supaya tidak spam log)
 - **MP3 tetap embed thumbnail** (jadi ada cover art)
-- Cookies per situs (YouTube / Bilibili / TikTok / Instagram / Reddit / Twitter/X)
+- Cookies per situs (YouTube / Bilibili / TikTok / Instagram / Reddit / Twitter/X / SoundCloud / Facebook / Twitch)
 - Pilihan kualitas video (best / 1080p60 / 720p60 / 480p) + subtitle (id/en/ja/none)
 - Mendukung clipboard & argumen URL
 
@@ -20,6 +20,9 @@ Menu interaktif **yt-dlp** untuk Windows, dengan fitur:
   - `instagram.txt`
   - `reddit.txt`
   - `twitter.txt`
+  - `soundcloud.txt`
+  - `facebook.txt`
+  - `twitch.txt`
 
 ---
 

--- a/ydl-menu.ps1
+++ b/ydl-menu.ps1
@@ -2,7 +2,7 @@
 # Fitur:
 # - Output dipisah (mp4/mp3/thumb + single/playlist)
 # - Downloader PER DOMAIN (internal vs aria2c balanced)
-# - Cookies per situs (YouTube, Bilibili, TikTok, Instagram, Reddit, Twitter/X)
+# - Cookies per situs (YouTube, Bilibili, TikTok, Instagram, Reddit, Twitter/X, SoundCloud, Facebook, Twitch)
 # - Pilihan kualitas video + subtitle
 # - Clipboard & argumen -Url
 
@@ -72,7 +72,7 @@ if ($PSBoundParameters.ContainsKey('Url') -and $Url) {
         if ($use -eq "" -or $use -match '^(y|Y)$') { $url = $clip }
     }
 }
-if (-not $url) { $url = Read-Host "Tempel link (YouTube/Bilibili/TikTok/Instagram/Reddit/Twitter)" }
+if (-not $url) { $url = Read-Host "Tempel link (YouTube/Bilibili/TikTok/Instagram/Reddit/Twitter/SoundCloud/Facebook/Twitch)" }
 if ([string]::IsNullOrWhiteSpace($url)) { Write-Host "URL kosong. Keluar."; exit 1 }
 
 # ====== Base args (tanpa aria2c default) ======
@@ -139,6 +139,9 @@ if (Test-Path $cookiesDir) {
     elseif ($url -match "instagram\.com")         { $cookie = "instagram.txt" }
     elseif ($url -match "reddit\.com")            { $cookie = "reddit.txt" }
     elseif ($url -match "twitter\.com|x\.com")    { $cookie = "twitter.txt" }
+    elseif ($url -match "soundcloud\.com")        { $cookie = "soundcloud.txt" }
+    elseif ($url -match "facebook\.com|fb\.watch") { $cookie = "facebook.txt" }
+    elseif ($url -match "twitch\.tv")             { $cookie = "twitch.txt" }
     if ($cookie) {
         $cookiePath = Join-Path $cookiesDir $cookie
         if (Test-Path $cookiePath) {
@@ -153,11 +156,11 @@ if (Test-Path $cookiesDir) {
 # ====== Pilih downloader berdasarkan domain ======
 $domain = $url.ToLower()
 
-if ($domain -match "twitter\.com|x\.com|reddit\.com|instagram\.com") {
+if ($domain -match "twitter\.com|x\.com|reddit\.com|instagram\.com|soundcloud\.com") {
     # File tunggal cenderung cocok aria2c
     Use-Aria2c -profile "balanced"     # -x4 -s4 -k1M
 }
-elseif ($domain -match "youtube\.com|youtu\.be|tiktok\.com|bilibili\.com") {
+elseif ($domain -match "youtube\.com|youtu\.be|tiktok\.com|bilibili\.com|facebook\.com|fb\.watch|twitch\.tv") {
     # Segmented (DASH/HLS): internal biasanya lebih cepat/stabil
     $dlArgs += @("--concurrent-fragments","10")
     Write-Host "Downloader: internal (concurrent fragments 10)" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary
- handle SoundCloud, Facebook, and Twitch URLs with domain-aware downloader selection
- add cookie lookup for new platforms and include them in documentation

## Testing
- `printf "3\n" | pwsh -NoLogo -NoProfile -File ydl-menu.ps1 -Url https://soundcloud.com/test` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68c6950cb6a08321af3754d4d0bd5930