### PR TITLE
feat: add m4a audio format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ydl-menu (PowerShell) — Final Version
 
 Menu interaktif **yt-dlp** untuk Windows, dengan fitur:
-- Output dipisah otomatis (mp4/webm/mp3/thumb + single/playlist)
+- Output dipisah otomatis (mp4/webm/mp3/m4a/thumb + single/playlist)
 - Downloader per domain (YouTube/TikTok/Bilibili/Facebook/Twitch → internal, Twitter/Reddit/Instagram/SoundCloud → aria2c)
 - **MP4/WebM tidak lagi embed thumbnail** (supaya tidak spam log)
-- **MP3 tetap embed thumbnail** (jadi ada cover art)
+- **MP3/M4A tetap embed thumbnail** (jadi ada cover art)
 - Cookies per situs (YouTube / Bilibili / TikTok / Instagram / Reddit / Twitter/X / SoundCloud / Facebook / Twitch)
 - Pilihan format & kualitas video (MP4/WebM: best / 1080p60 / 720p60 / 480p) + subtitle (id/en/ja/none)
 - Mendukung clipboard & argumen URL
@@ -72,11 +72,16 @@ Downloads\ydl\
  │   │   └─ Judul Video.mp3 (dengan cover art)
  │   └─ Nama Playlist\
  │       └─ ...
+ ├─ m4a\
+ │   ├─ single\
+ │   │   └─ Judul Video.m4a (dengan cover art)
+ │   └─ Nama Playlist\
+ │       └─ ...
  └─ thumb\
-     ├─ single\
-     │   └─ Judul Video.jpg
-     └─ Nama Playlist\
-         └─ ...
+    ├─ single\
+    │   └─ Judul Video.jpg
+    └─ Nama Playlist\
+        └─ ...
 ```
 
 ---

--- a/ydl-menu.ps1
+++ b/ydl-menu.ps1
@@ -1,6 +1,6 @@
 # ydl-menu.ps1 — yt-dlp interactive menu (PowerShell 5.1/7)
 # Fitur:
-# - Output dipisah (mp4/mp3/thumb + single/playlist)
+# - Output dipisah (mp4/webm/mp3/m4a/thumb + single/playlist)
 # - Downloader PER DOMAIN (internal vs aria2c balanced)
 # - Cookies per situs (YouTube, Bilibili, TikTok, Instagram, Reddit, Twitter/X, SoundCloud, Facebook, Twitch)
 # - Pilihan kualitas video + subtitle
@@ -82,14 +82,13 @@ $dlArgs = @(
 
 # ====== Output base & pemisahan ======
 $base = Join-Path $HOME "Downloads/ydl"
-$null = New-Item -ItemType Directory -Force -Path "$base/mp4/single","$base/webm/single","$base/mp3/single","$base/thumb/single" -ErrorAction SilentlyContinue
+$null = New-Item -ItemType Directory -Force -Path "$base/mp4/single","$base/webm/single","$base/mp3/single","$base/m4a/single","$base/thumb/single" -ErrorAction SilentlyContinue
 $dlArgs += @(
-  "-P","audio:$base/mp3/%(playlist_title|single)s/",
   "-P","thumbnail:$base/thumb/%(playlist_title|single)s/"
 )
 
 # ====== Mode ======
-$modeChoice = Read-Choice "Pilih mode unduhan:" @("MP4 (video)","WEBM (video)","MP3 (audio saja)","Thumbnail saja")
+$modeChoice = Read-Choice "Pilih mode unduhan:" @("MP4 (video)","WEBM (video)","MP3 (audio saja)","M4A (audio saja)","Thumbnail saja")
 
 switch ($modeChoice) {
     1 { # MP4
@@ -167,9 +166,20 @@ switch ($modeChoice) {
     }
 
     3 { # MP3
-        $dlArgs += @("--extract-audio","--audio-format","mp3","--audio-quality","0","--embed-thumbnail","--add-metadata","--no-write-subs")
+        $dlArgs += @(
+            "--extract-audio","--audio-format","mp3","--audio-quality","0",
+            "--embed-thumbnail","--add-metadata","--no-write-subs",
+            "-P","audio:$base/mp3/%(playlist_title|single)s/"
+        )
     }
-    4 { # Thumbnail only
+    4 { # M4A
+        $dlArgs += @(
+            "--extract-audio","--audio-format","m4a","--audio-quality","0",
+            "--embed-thumbnail","--add-metadata","--no-write-subs",
+            "-P","audio:$base/m4a/%(playlist_title|single)s/"
+        )
+    }
+    5 { # Thumbnail only
         $dlArgs += @("--skip-download","--write-thumbnail","--no-write-subs")
     }
 }


### PR DESCRIPTION
## Summary
- add M4A audio-only download option with best quality and thumbnail embedding
- document new M4A output format in README

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Output 'test'"` *(fails: command not found)*
- `powershell -NoLogo -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c69e56435483218846a76f002414ce