### PR TITLE
feat: add frame capture thumbnail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Menu interaktif **yt-dlp** untuk Windows, dengan fitur:
 - Pilihan format & kualitas video (MP4/WebM: best / 1080p60 / 720p60 / 480p) + subtitle (id/en/ja/none)
 - Mendukung clipboard & argumen URL
 - Video <1 menit (single) otomatis kualitas terbaik
+- Thumbnail: pilih thumbnail bawaan atau frame dari durasi tertentu
 
 ---
 


### PR DESCRIPTION
## Summary
- allow choosing site thumbnail or a frame at a specific timestamp
- document thumbnail options

## Testing
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ydl-menu.ps1 -Url https://example.com` *(fails: pwsh not found)*
- `python3 -m pip install yt-dlp` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c69fecd9f88321ab6234c9524224d3