### PR TITLE
Streamline scripts and improve thumbnail handling

### DIFF
--- a/ydl-menu.cmd
+++ b/ydl-menu.cmd
@@ -1,4 +1,3 @@
 @echo off
 REM Jalankan ydl-menu dengan URL dari clipboard
 powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0ydl-menu.ps1" -Clipboard
-pause


### PR DESCRIPTION
## Summary
- remove unused tool check helper
- simplify output directory creation
- quote file paths in thumbnail extraction command
- drop unnecessary pause from Windows launcher

## Testing
- `pwsh -NoLogo -NoProfile -File ./ydl-menu.ps1 -Url https://example.com` *(fails: `command not found: pwsh`)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b87ec38883218053057b04dd5ee7