### PR TITLE
refactor: streamline custom thumbnail capture

### DIFF
--- a/ydl-menu.ps1
+++ b/ydl-menu.ps1
@@ -69,15 +69,10 @@ $dlArgs = @(
   "--no-mtime","--embed-metadata","--windows-filenames","--no-restrict-filenames"
 )
 
-$thumbFrame = $null
-
 # ====== Output base & pemisahan ======
 $base = Join-Path $HOME "Downloads/ydl"
 $dirs = "$base/mp4/single","$base/webm/single","$base/mp3/single","$base/m4a/single","$base/thumb/single"
 $null = New-Item -ItemType Directory -Force -Path $dirs -ErrorAction SilentlyContinue
-$dlArgs += @(
-  "-P","thumbnail:$base/thumb/%(playlist_title|single)s/"
-)
 
 # ====== Mode ======
 $outputOverride = $null
@@ -176,14 +171,17 @@ switch ($modeChoice) {
         $thumbChoice = Read-Choice "Pilih jenis thumbnail:" @("Thumbnail default","Thumbnail dari durasi tertentu")
         switch ($thumbChoice) {
             1 {
-                $dlArgs += @("--skip-download","--write-thumbnail","--no-write-subs")
+                $dlArgs += @(
+                    "--skip-download","--write-thumbnail","--no-write-subs",
+                    "-P","thumbnail:$base/thumb/%(playlist_title|single)s/"
+                )
             }
             2 {
                 $time = Read-Host "Masukkan waktu (detik atau mm:ss)"
 
                 $execCmd = "ffmpeg -ss $time -i %(filepath)q -frames:v 1 `"%(filepath)s.jpg`" && ren `"%(filepath)s.jpg`" `"%(filename)s.jpg`" && del %(filepath)q"
                 $outputOverride = "$base/thumb/%(playlist_title|single)s/%(title)s [%(uploader)s] [%(id)s].%(ext)s"
-                $dlArgs += @("--merge-output-format","mp4","--no-write-subs","-f","bv*+ba/b","--exec",$execCmd)
+                $dlArgs += @("--no-write-subs","-f","bestvideo","--exec",$execCmd)
             }
         }
     }
@@ -238,32 +236,10 @@ else {
 }
 
 # ====== Eksekusi ======
-if ($thumbFrame) {
-    Write-Host "`n> Mengambil thumbnail dari durasi $thumbFrame" -ForegroundColor Cyan
-    $tmpBase   = [IO.Path]::GetTempFileName()
-    $manualArgs = $dlArgs + @("-f","bestvideo","-o",$tmpBase + ".%(ext)s")
-    $pretty = ($manualArgs + @($url) | ForEach-Object { if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ } }) -join ' '
-    Write-Host ("yt-dlp " + $pretty)
-    & yt-dlp @manualArgs $url
-    $videoFile = Get-ChildItem ($tmpBase + ".*") | Select-Object -First 1 -ExpandProperty FullName
-    $infoJson = yt-dlp --dump-single-json --no-warnings $url 2>$null
-    $info     = $infoJson | ConvertFrom-Json
-    $folder   = if ($info.playlist_title) { $info.playlist_title } else { "single" }
-    $name     = "{0} [{1}] [{2}]" -f $info.title, $info.uploader, $info.id
-    $outDir   = Join-Path $base "thumb/$folder"
-    $null     = New-Item -ItemType Directory -Force -Path $outDir
-    $outFile  = Join-Path $outDir ($name + ".jpg")
-    ffmpeg -ss $thumbFrame -i $videoFile -vframes 1 $outFile
-    $ec = $LASTEXITCODE
-    Remove-Item ($tmpBase + ".*") -Force
-    Write-Host "`nSelesai. ExitCode: $ec"
-    if ($ec -ne 0) { Write-Host "Ada error. Coba tambahkan --verbose untuk detail." -ForegroundColor Yellow }
-} else {
-    Write-Host "`n> Menjalankan yt-dlp dengan opsi berikut:" -ForegroundColor Cyan
-    $pretty = ($dlArgs + @($url) | ForEach-Object { if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ } }) -join ' '
-    Write-Host ("yt-dlp " + $pretty)
-    & yt-dlp @dlArgs $url
-    $ec = $LASTEXITCODE
-    Write-Host "`nSelesai. ExitCode: $ec"
-    if ($ec -ne 0) { Write-Host "Ada error. Coba tambahkan --verbose untuk detail." -ForegroundColor Yellow }
-}
+Write-Host "`n> Menjalankan yt-dlp dengan opsi berikut:" -ForegroundColor Cyan
+$pretty = ($dlArgs + @($url) | ForEach-Object { if ($_ -match '\s') { '"{0}"' -f $_ } else { $_ } }) -join ' '
+Write-Host ("yt-dlp " + $pretty)
+& yt-dlp @dlArgs $url
+$ec = $LASTEXITCODE
+Write-Host "`nSelesai. ExitCode: $ec"
+if ($ec -ne 0) { Write-Host "Ada error. Coba tambahkan --verbose untuk detail." -ForegroundColor Yellow }


### PR DESCRIPTION
## Summary
- move thumbnail output path into thumbnail-only mode to avoid conflicts
- speed up duration-based thumbnail capture by downloading video-only and drop unused manual code

## Testing
- ⚠️ `pwsh --version` *(missing: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be78e21c832182e0ed723a4c7dd3