### PR TITLE
Use PNG cover art for audio and JPEG for thumbnail downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Menu interaktif **yt-dlp** untuk Windows, dengan fitur:
 - Output dipisah otomatis (mp4/webm/mp3/m4a/thumb + single/playlist)
 - Downloader per domain (YouTube/TikTok/Bilibili/Facebook/Twitch → internal, Twitter/Reddit/Instagram/SoundCloud → aria2c)
 - **MP4/WebM tidak lagi embed thumbnail** (supaya tidak spam log)
-- **MP3/M4A tetap embed thumbnail** (jadi ada cover art)
+- **MP3/M4A embed thumbnail PNG** (jadi ada cover art)
 - Cookies per situs (YouTube / Bilibili / TikTok / Instagram / Reddit / Twitter/X / SoundCloud / Facebook / Twitch)
 - Pilihan format & kualitas video (MP4/WebM: best / 1080p60 / 720p60 / 480p) + subtitle (id/en/ja/none)
 - Mendukung clipboard & argumen URL
 - Video <1 menit (single) otomatis kualitas terbaik
-- Opsi thumbnail: ambil thumbnail bawaan atau frame video pada waktu tertentu (ffmpeg)
+- Opsi thumbnail: ambil thumbnail bawaan (JPEG) atau frame video pada waktu tertentu (ffmpeg)
 
 ---
 

--- a/ydl-menu.ps1
+++ b/ydl-menu.ps1
@@ -156,14 +156,14 @@ switch ($modeChoice) {
     3 { # MP3
         $dlArgs += @(
             "--extract-audio","--audio-format","mp3","--audio-quality","0",
-            "--embed-thumbnail","--add-metadata","--no-write-subs",
+            "--embed-thumbnail","--convert-thumbnails","png","--add-metadata","--no-write-subs",
             "-P","audio:$base/mp3/%(playlist_title|single)s/"
         )
     }
     4 { # M4A
         $dlArgs += @(
             "--extract-audio","--audio-format","m4a","--audio-quality","0",
-            "--embed-thumbnail","--add-metadata","--no-write-subs",
+            "--embed-thumbnail","--convert-thumbnails","png","--add-metadata","--no-write-subs",
             "-P","audio:$base/m4a/%(playlist_title|single)s/"
         )
     }
@@ -172,7 +172,7 @@ switch ($modeChoice) {
         switch ($thumbChoice) {
             1 {
                 $dlArgs += @(
-                    "--skip-download","--write-thumbnail","--no-write-subs",
+                    "--skip-download","--write-thumbnail","--convert-thumbnails","jpg","--no-write-subs",
                     "-P","thumbnail:$base/thumb/%(playlist_title|single)s/"
                 )
             }


### PR DESCRIPTION
## Summary
- Embed PNG thumbnails in MP3/M4A audio downloads
- Convert standalone thumbnail downloads to JPEG format
- Document new thumbnail formats in README

## Testing
- ⚠️ `pwsh -NoLogo -NoProfile -Command "Write-Host 'PowerShell OK'"` *(PowerShell not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c32ee9988321893080e727209a84