### PR TITLE
Fix ffmpeg exec path quoting for timestamped thumbnails

### DIFF
--- a/ydl-menu.ps1
+++ b/ydl-menu.ps1
@@ -178,8 +178,9 @@ switch ($modeChoice) {
             }
             2 {
                 $time = Read-Host "Masukkan waktu (detik atau mm:ss)"
+                $thumbPath = "$base/thumb/%(playlist_title|single)s/%(title)s [%(uploader)s] [%(id)s].jpg"
 
-                $execCmd = "ffmpeg -ss $time -i %(filepath)q -frames:v 1 `"%(filepath)s.jpg`" && ren `"%(filepath)s.jpg`" `"%(filename)s.jpg`" && del %(filepath)q"
+                $execCmd = "ffmpeg -y -ss $time -i %(filepath)q -frames:v 1 \"$thumbPath\" && del %(filepath)q"
                 $outputOverride = "$base/thumb/%(playlist_title|single)s/%(title)s [%(uploader)s] [%(id)s].%(ext)s"
                 $dlArgs += @("--no-write-subs","-f","bestvideo","--exec",$execCmd)
             }


### PR DESCRIPTION
## Summary
- fix timestamped thumbnail extraction by using direct ffmpeg output path and clean up temp video

## Testing
- `pwsh -NoLogo -Command "Get-Date"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c71431488321b7b97da475ab5a59