### PR TITLE
Fix quote escaping for custom thumbnail command

### DIFF
--- a/ydl-menu.ps1
+++ b/ydl-menu.ps1
@@ -179,7 +179,7 @@ switch ($modeChoice) {
             2 {
                 $time = Read-Host "Masukkan waktu (detik atau mm:ss)"
                 $thumbPath = "$base/thumb/%(playlist_title|single)s/%(title)s [%(uploader)s] [%(id)s].jpg"
-                $execCmd = "ffmpeg -y -ss $time -i %(filepath)q -frames:v 1 \"$thumbPath\" && del %(filepath)q"
+                $execCmd = "ffmpeg -y -ss $time -i %(filepath)q -frames:v 1 `"$thumbPath`" && del %(filepath)q"
                 $outputOverride = "$base/thumb/%(playlist_title|single)s/%(title)s [%(uploader)s] [%(id)s].%(ext)s"
                 $dlArgs += @("--no-write-subs","-f","bestvideo","--exec",$execCmd)
             }


### PR DESCRIPTION
## Summary
- escape `--exec` command's thumbnail path using PowerShell backticks to prevent parser errors

## Testing
- `pwsh -NoProfile -Command "[System.Management.Automation.Language.Parser]::ParseFile('ydl-menu.ps1',[ref]$null,[ref]$null)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ced8269883218f6a057c9a87b79e